### PR TITLE
pagination+loadingPage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12943,6 +12943,11 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@reduxjs/toolkit": "^1.6.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
@@ -11,8 +12,8 @@
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-beta.6",
     "react-dom": "^17.0.2",
+    "react-loading": "^2.0.3",
     "react-router-dom": "^5.3.0",
-    "@reduxjs/toolkit": "^1.6.1",
     "react-scripts": "4.0.3",
     "react-transition-group": "^4.4.2",
     "styled-components": "^5.3.1",

--- a/src/Components/PaginationButton/PaginationButton.js
+++ b/src/Components/PaginationButton/PaginationButton.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { Div, Button, Icon } from "atomize";
+
+const PaginationButton = ({ page, handlePageClick, data, limit }) => {
+  return (
+    <Div m={{ t: "1rem" }} pos="absolute" right="5rem" bottom="1rem" d="flex">
+      {page == 1 ? (
+        ""
+      ) : (
+        <Button
+          h="2rem"
+          p={{ x: "1rem" }}
+          textSize="caption"
+          textColor="info700"
+          hoverTextColor="info900"
+          bg="white"
+          hoverBg="info200"
+          border="1px solid"
+          borderColor="info700"
+          hoverBorderColor="info900"
+          m={{ r: "0.5rem" }}
+          onClick={() => handlePageClick("back")}
+        >
+          <Icon name="LongLeft" size="20px" color="info700" />
+        </Button>
+      )}
+
+      <Div
+        h="2rem"
+        p={{ x: "1rem" }}
+        textSize="title"
+        textColor="info700"
+        m={{ r: "0.5rem" }}
+      >
+        {page}
+      </Div>
+
+      {data.length === limit ? (
+        <Button
+          h="2rem"
+          p="1rem"
+          textSize="caption"
+          textColor="info700"
+          hoverTextColor="info900"
+          bg="white"
+          hoverBg="info200"
+          border="1px solid"
+          borderColor="info700"
+          hoverBorderColor="info900"
+          m={{ r: "0.5rem" }}
+          hoverShadow="4"
+          onClick={() => handlePageClick("next")}
+        >
+          <Icon name="LongRight" size="20px" color="info700" />
+        </Button>
+      ) : (
+        ""
+      )}
+    </Div>
+  );
+};
+
+export default PaginationButton;

--- a/src/Components/PaginationButton/index.js
+++ b/src/Components/PaginationButton/index.js
@@ -1,0 +1,1 @@
+export { default } from "./PaginationButton";

--- a/src/pages/LoadingPage/LoadingPage.js
+++ b/src/pages/LoadingPage/LoadingPage.js
@@ -1,0 +1,26 @@
+import React from "react";
+import styled from "styled-components";
+import ReactLoading from "react-loading";
+
+const Loading = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #c7c1c178;
+  z-index: 2;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const LoadingPage = () => {
+  return (
+    <Loading>
+      <ReactLoading type="cylon" color="#83b1c9" height={80} width={80} />
+    </Loading>
+  );
+};
+
+export default LoadingPage;

--- a/src/pages/LoadingPage/index.js
+++ b/src/pages/LoadingPage/index.js
@@ -1,0 +1,1 @@
+export { default } from "./LoadingPage";


### PR DESCRIPTION
本次新增
- 分頁按鈕
- loadingPage

分頁按鈕設定成
- 如果 page 是 1 的時候，不會有往回的按鈕
- 判斷 data 的長度如果等於一頁 data 的筆數才會有往下一頁的按鈕
![image](https://user-images.githubusercontent.com/82195336/137326243-1adbcb21-c342-47cb-b9a8-0cad66ed37a7.png)

******
目前 loadingPage 是使用這個套件
[react-loading](https://www.npmjs.com/package/react-loading)
我目前是只有在自己要用到的頁面寫上
![image](https://user-images.githubusercontent.com/82195336/137326839-b3b088c2-7d1b-4b85-b5ab-e90998124e94.png)


以上!